### PR TITLE
Add a script to create definitions of SBND raw data files per run.

### DIFF
--- a/scripts/create_raw_definition_sbnd.py
+++ b/scripts/create_raw_definition_sbnd.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import sys
+import samweb_cli
+
+samweb = samweb_cli.SAMWebClient(experiment='sbnd')
+
+if len(sys.argv) != 2:
+    print ("Please specify run number.")
+    sys.exit(1)
+    
+defname = "sbnd_runset_%s_raw" % (sys.argv[1])
+
+#print("Definition name is %s"%defname)
+
+defexist = True
+
+try:
+    info = samweb.descDefinition(defname)
+except:
+    defexist = False
+
+if defexist:
+    print("Definition exists:")
+    print(info)
+else:
+    dimension = "run_number %s and data_tier raw and sbn_dm.detector sbn_nd" % (sys.argv[1])
+    info = samweb.listFilesSummary(dimension)
+    #print(info['file_count'])
+    if info['file_count'] == 0:
+        print("No files found with dimensions '%s'"%dimension)
+        sys.exit(1)
+    else:
+        samweb.createDefinition(defname, dimension, "sbndpro")
+        info = samweb.descDefinition(defname)
+        print("New definition %s created:" % defname)
+        print(info)
+        print(samweb.listFilesSummary("defname: %s"%defname))

--- a/scripts/create_raw_definition_sbnd.py
+++ b/scripts/create_raw_definition_sbnd.py
@@ -1,3 +1,13 @@
+########################################################################
+# File:        create_raw_definition_sbnd.py
+# Author:      tjyang@fnal.gov
+#
+# Script to declare SBND raw data files
+#
+# Usage: create_raw_definition_sbnd.py run_number
+#
+########################################################################
+
 #!/usr/bin/env python
 
 import sys


### PR DESCRIPTION
Add a script to create definitions of SBND raw data files per run.
It checks if the definition already exists before creating the new one. 
It also checks if there are any raw data files in the requested run first. 

<pre>create_raw_definition_sbnd.py 12552
New definition sbnd_runset_12552_raw created:
Definition Name: sbnd_runset_12552_raw
  Definition Id: 149461
  Creation Date: 2024-04-12T16:06:10+00:00
       Username: sbndpro
          Group: sbnd
     Dimensions: run_number 12552 and data_tier raw and sbn_dm.detector sbn_nd
{'file_count': 15, 'total_file_size': 3044600825, 'total_event_count': None}</pre>
